### PR TITLE
Allow to serve libraries from hidden directories

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -95,14 +95,16 @@ HTTP.prototype.buildServer = function(opts) {
     res.end();
   }
 
-  var handlePontePublic = st(__dirname + "/../public", {
+  var handlePontePublic = st(opts.publicDirs.ponte, {
     index: false,
-    passthrough: true
+    passthrough: true,
+    dot: opts.publicDirs.mosca.match(/(^|\/)\./)
   });
-
-  var handleMoscaPublic = st(__dirname + "/../node_modules/mosca/public", {
+  
+  var handleMoscaPublic = st(opts.publicDirs.mosca, {
     index: false,
-    passthrough: false
+    passthrough: false,
+    dot: opts.publicDirs.mosca.match(/(^|\/)\./)
   });
 
   function handleGetResource(subject, topic, req, res) {

--- a/lib/servers.js
+++ b/lib/servers.js
@@ -83,7 +83,11 @@ module.exports = [{
   factory: HTTP,
   defaults: {
     port: 3000,
-    serveLibraries: true
+    serveLibraries: true,
+    publicDirs: {
+      ponte: __dirname + "/../public",
+      mosca: __dirname + "/../node_modules/mosca/public"
+    }
   }
 }, {
   service: "coap",

--- a/test/libraries_inside_hidden_dir.js
+++ b/test/libraries_inside_hidden_dir.js
@@ -1,0 +1,88 @@
+var request = require("supertest");
+var ponte = require("../lib/ponte");
+var async = require("async");
+var fs = require("fs");
+
+describe("Ponte as an HTTP server that serves libraries", function() {
+
+  var settings;
+  var instance;
+  
+  function remove() {
+    try {
+      fs.unlinkSync(__dirname + "/.hidden/mqttws31.js");
+      fs.unlinkSync(__dirname + "/.hidden/mqtt.js");
+      fs.rmdirSync(__dirname + "/.hidden");
+    } catch (e) {
+      return e.code != 'NOENT';
+    }
+    return true;
+  }
+
+  function cp(opts, done) {
+    var toStream = fs.createWriteStream(opts.to);
+    fs.createReadStream(opts.from).pipe(toStream);
+    toStream.on("finish", done);
+  }
+
+  function prepare(defaults, newSettings, done) {
+    defaults.http.publicDirs = {
+      ponte: __dirname + "/../public",
+      mosca: __dirname + "/../node_modules/mosca/public"
+    };
+    if (!remove())
+      return done(new Error("Failed to remove test artifacts from previous attempt."));
+    try {
+      fs.mkdirSync(__dirname + "/.hidden");
+    } catch (e) {
+      return done(new Error("Failed to create .hidden directory."));
+    }
+    async.map([
+      { 
+        from: defaults.http.publicDirs.ponte + "/mqttws31.js", 
+        to: newSettings.http.publicDirs.ponte + "/mqttws31.js"
+      },
+      { 
+        from: defaults.http.publicDirs.mosca + "/mqtt.js", 
+        to: newSettings.http.publicDirs.mosca + "/mqtt.js"
+      },
+    ], cp, done);
+  }
+
+  beforeEach(function(done) {
+    settings = ponteSettings();
+    settings.http.publicDirs = {
+      ponte: __dirname + "/.hidden",
+      mosca: __dirname + "/.hidden"
+    };
+    prepare(ponteSettings(), settings, function(err){
+      if (err)
+        return done(err);
+      instance = ponte(settings, done);
+    });
+  });
+
+  afterEach(function(done) {
+    instance.close(function(err){
+      if (!remove())
+        return done(new Error("Failed to cleanup the test artifacts"));
+      done(err);
+    });
+  });
+
+  describe("with libraries inside the " + __dirname + "/.hidden directory", function() {
+    it("should serve the mqttws31.js file", function(done) {
+      var file = fs.readFileSync(__dirname + "/../public/mqttws31.js");
+      request(instance.http.server)
+        .get("/mqttws31.js")
+        .expect(200, file.toString(), done);
+    });
+
+    it("should serve the mqtt.js file", function(done) {
+      var file = fs.readFileSync(__dirname + "/../node_modules/mosca/public/mqtt.js");
+      request(instance.http.server)
+        .get("/mqtt.js")
+        .expect(200, file.toString(), done);
+    });
+  });
+});


### PR DESCRIPTION
The `st` module denies to serve libraries from path that contains dot dir (hidden directory) e.g. `~/.nvm/v0.10.36/node_modules/ponte/public` unless [the dot option is set to true](https://github.com/isaacs/st/blob/master/st.js#L240). This condition is relevant when `node` is installed using `nvm` and `ponte` is installed globally. Hence, the [dot](https://github.com/rockybars/ponte/compare/public-libraries-inside-dot-dir?expand=1#diff-1c0f1c434b17b7f8795d44a51a14320aR101) option for `st` call inside the `handleMoscaPublic()` and `handlePontePublic()` are enabled when the path contains hidden dir.

To make it testable, the `opts.publicDirs` is added.